### PR TITLE
Remove remaining outdated copy notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 This is the starting repository for student work for CSE 212 at BYU-Idaho. It should be used as a template repository for each student to start their own repo.
 
 # Permissions to use
-This code is used for class assignments for CSE 211 at Brigham Young University-Idaho. Copying this code is a violation of the BYU-Idaho Honor Code.
+This code is used for class assignments for CSE 212 at Brigham Young University-Idaho. Copying this code is a violation of the BYU-Idaho Honor Code.
 
 To ensure that you are learning the concepts of the course, any code that you add to this starter template should be your own work. If you have any questions about this, ask your teacher.

--- a/week01/analyze/Search.cs
+++ b/week01/analyze/Search.cs
@@ -1,15 +1,5 @@
 ﻿using System.Diagnostics;
 
-/*
- * CSE212 
- * (c) BYU-Idaho
- * 02-Prove - Problem 2
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code with others or 
- * to post it online.  Storage into a personal and private repository (e.g. private
- * GitHub repository, unshared Google Drive folder) is acceptable.
- *
- */
 public static class Search {
     public static void Run() {
         Console.WriteLine("{0,15}{1,15}{2,15}{3,15}{4,15}", "n", "sort1-count", "sort2-count", "sort1-time",

--- a/week01/analyze/Sorting.cs
+++ b/week01/analyze/Sorting.cs
@@ -1,14 +1,4 @@
-﻿/*
- * CSE212 
- * (c) BYU-Idaho
- * 02-Prove - Problem 1.1
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code with others or 
- * to post it online.  Storage into a personal and private repository (e.g. private
- * GitHub repository, unshared Google Drive folder) is acceptable.
- *
- */
-public static class Sorting {
+﻿public static class Sorting {
     public static void Run() {
         var numbers = new[] { 3, 2, 1, 6, 4, 9, 8 };
         SortArray(numbers);

--- a/week01/analyze/StandardDeviation.cs
+++ b/week01/analyze/StandardDeviation.cs
@@ -1,14 +1,4 @@
-﻿/*
- * CSE212 
- * (c) BYU-Idaho
- * 02-Teach - Problem 1.2
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code with others or 
- * to post it online.  Storage into a personal and private repository (e.g. private
- * GitHub repository, unshared Google Drive folder) is acceptable.
- *
- */
-/// <summary>
+﻿/// <summary>
 /// These 3 functions will (in different ways) calculate the standard
 /// deviation from a list of numbers.  The standard deviation
 /// is defined as the square root of the variance.  The variance is 

--- a/week01/code/Program.cs
+++ b/week01/code/Program.cs
@@ -1,12 +1,2 @@
-﻿/*
- * CSE212 
- * (c) BYU-Idaho
- * 09-Prove
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code with others or 
- * to post it online.  Storage into a personal and private repository (e.g. private
- * GitHub repository, unshared Google Drive folder) is acceptable.
- */
-
-Console.WriteLine("\n======================\nProve 1 - Arrays / Lists\n======================");
+﻿Console.WriteLine("\n======================\nProve 1 - Arrays / Lists\n======================");
 ArraysTester.Run();

--- a/week01/teach/Algorithms.cs
+++ b/week01/teach/Algorithms.cs
@@ -1,15 +1,5 @@
 ﻿using System.Diagnostics;
 
-/*
- * CSE212 
- * (c) BYU-Idaho
- * 02-Teach - Problem 1
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code with others or 
- * to post it online.  Storage into a personal and private repository (e.g. private
- * GitHub repository, unshared Google Drive folder) is acceptable.
- *
- */
 public static class Algorithms {
     public static void Run() {
         Console.WriteLine("{0,15}{1,15}{2,15}{3,15}{4,15}{5,15}{6,15}", "n", "alg1-count", "alg2-count", "alg3-count",

--- a/week01/teach/Program.cs
+++ b/week01/teach/Program.cs
@@ -1,15 +1,4 @@
-﻿/*
- * CSE212 
- * (c) BYU-Idaho
- * 01-Teach
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code with others or 
- * to post it online.  Storage into a personal and private repository (e.g. private
- * GitHub repository, unshared Google Drive folder) is acceptable.
- */
-
-
-Console.WriteLine("\n======================\nDivisors\n======================");
+﻿Console.WriteLine("\n======================\nDivisors\n======================");
 Divisors.Run();
 
 Console.WriteLine("\n======================\nArray Selector\n======================");

--- a/week02/analyze/MysteryStack1.cs
+++ b/week02/analyze/MysteryStack1.cs
@@ -1,14 +1,4 @@
-﻿/*
- * CSE212 
- * (c) BYU-Idaho
- * 03-Prove - Problem 1
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code
- * with others or to post it online.  Storage into a personal and private
- * repository (e.g. private GitHub repository, unshared Google Drive
- * folder) is acceptable.
- */
-public static class MysteryStack1 {
+﻿public static class MysteryStack1 {
     public static string Run(string text) {
         var stack = new Stack<char>();
         foreach (var letter in text)

--- a/week02/analyze/MysteryStack2.cs
+++ b/week02/analyze/MysteryStack2.cs
@@ -1,14 +1,4 @@
-﻿/*
- * CSE212 
- * (c) BYU-Idaho
- * 03-Prove - Problem 2
- * 
- * It is a violation of BYU-Idaho Honor Code to post or share this code
- * with others or to post it online.  Storage into a personal and private
- * repository (e.g. private GitHub repository, unshared Google Drive
- * folder) is acceptable.
- */
-public static class MysteryStack2 {
+﻿public static class MysteryStack2 {
     private static bool IsFloat(string text) {
         return float.TryParse(text, out _);
     }


### PR DESCRIPTION
Looks like we missed a few spots where the old code-copying notice still existed.