### PR TITLE
Invert IsAnagram check in efficiency test to force the whole list to be checked

### DIFF
--- a/week03/code/SetsAndMaps_Tests.cs
+++ b/week03/code/SetsAndMaps_Tests.cs
@@ -184,12 +184,12 @@ public class IsAnagramTests
     }
 
     // If this test takes longer than 5 seconds to run, your code is too inefficient.
-    //  On my machine, this executes in ~1 second with an efficient implementation.
+    //  On my machine, this executes in ~3 seconds with an efficient implementation.
     [TestMethod, Timeout(5000)]
     public void IsAnagram_Efficiency()
     {
         var rand = new Random();
-        var length = 30_000_000;
+        var length = 60_000_000;
         var a_array = new char[length];
         var b_array = new char[length];
 

--- a/week03/code/SetsAndMaps_Tests.cs
+++ b/week03/code/SetsAndMaps_Tests.cs
@@ -195,11 +195,12 @@ public class IsAnagramTests
 
         for (int i = 0; i < length; ++i)
         {
-            a_array[i] = (char)rand.Next(256);
-            b_array[i] = (char)rand.Next(256);
+            char c = (char)rand.Next(256);
+            a_array[i] = c;
+            b_array[i] = c;
         }
 
-        Assert.IsFalse(SetsAndMaps.IsAnagram(new string(a_array), new string(b_array)));
+        Assert.IsTrue(SetsAndMaps.IsAnagram(new string(a_array), new string(b_array)));
     }
 }
 


### PR DESCRIPTION
The `IsAnagram_Efficiency` test is trying to figure out if the big O complexity of the `IsAnagram` method is correct by giving it two very large inputs. It seems like there are some cases where bad implementations are still passing the test (executing in < 5 seconds), so make the test harder. 

Here are 2 common incorrect implementations I see that I've tested always fail this new test on my machine:
```
        word1 = word1.Replace(" ", "").ToLower();
        word2 = word2.Replace(" ", "").ToLower();

        word1 = SortString(word1);
        word2 = SortString(word2);
        return word1 == word2;
```

```
        if (word1.Length != word2.Length)
        {
            return false;
        }
        else if (word1.OrderBy(c => c).SequenceEqual(word2.OrderBy(c => c)))
        {
            return true;
        }
        else
        {
            return false;
        }
```

I also tested 2 different variations of correct implementations run in 3 seconds on my same machine.

Hopefully these will still work on a grader's machine which may be slower than mine. I'm not too concerned if they don't always work perfectly on student's machines. The student could complain "it all passes" but it's clear they aren't even using the data structure of the week's lesson and probably got their implementations off the internet. These tests exist purely to help us when grading know if something has the wrong big O without having to look at all the code exhaustively.