### PR TITLE
Warn students about modifying methods we use for private tests

### DIFF
--- a/week02/code/PriorityQueue.cs
+++ b/week02/code/PriorityQueue.cs
@@ -36,7 +36,7 @@
     }
 
     // DO NOT MODIFY THE CODE IN THIS METHOD
-    // We rely on this method in the tests we run while grading, so changes to it will cause you to lose points.
+    // The graders rely on this method to check if you fixed all the bugs, so changes to it will cause you to lose points.
     public override string ToString()
     {
         return $"[{string.Join(", ", _queue)}]";
@@ -55,7 +55,7 @@ internal class PriorityItem
     }
 
     // DO NOT MODIFY THE CODE IN THIS METHOD
-    // We rely on this method in the tests we run while grading, so changes to it will cause you to lose points.
+    // The graders rely on this method to check if you fixed all the bugs, so changes to it will cause you to lose points.
     public override string ToString()
     {
         return $"{Value} (Pri:{Priority})";

--- a/week02/code/PriorityQueue.cs
+++ b/week02/code/PriorityQueue.cs
@@ -35,6 +35,8 @@
         return value;
     }
 
+    // DO NOT MODIFY THE CODE IN THIS METHOD
+    // We rely on this method in the tests we run while grading, so changes to it will cause you to lose points.
     public override string ToString()
     {
         return $"[{string.Join(", ", _queue)}]";
@@ -52,6 +54,8 @@ internal class PriorityItem
         Priority = priority;
     }
 
+    // DO NOT MODIFY THE CODE IN THIS METHOD
+    // We rely on this method in the tests we run while grading, so changes to it will cause you to lose points.
     public override string ToString()
     {
         return $"{Value} (Pri:{Priority})";


### PR DESCRIPTION
We use these `ToString` methods in our private tests to inspect the internal state of the queue. We have private tests here to verify if students have been thorough enough in the tests they are supposed to write, given a list of requirements. Some students have modified these methods and then fail our private tests, which isn't really fair because we never specified that they couldn't modify these.