### PR TITLE
Fix maze indexing

### DIFF
--- a/week05/code/Maze.cs
+++ b/week05/code/Maze.cs
@@ -51,7 +51,7 @@ public class Maze
     /// </summary>
     public bool IsEnd(int x, int y)
     {
-        return Data[y * Height + x] == 2;
+        return Data[y * Width + x] == 2;
     }
 
 
@@ -68,7 +68,7 @@ public class Maze
         if (y > Height - 1 || y < 0)
             return false;
         // Can't go through a wall
-        if (Data[y * Height + x] == 0)
+        if (Data[y * Width + x] == 0)
             return false;
         // Can't go if we have already been there (don't go in circles)
         if (currPath.Contains((x, y)))


### PR DESCRIPTION
A student noticed that we are incorrectly calculating the maze position in week 5. In practice, this has never mattered because the maze is square (and the documentation states that it will always be square). However, we should fix this just in case we change that in the future.